### PR TITLE
Reclaim HTTP memory after boot if possible

### DIFF
--- a/profile/airootfs/etc/rc.installer
+++ b/profile/airootfs/etc/rc.installer
@@ -1,4 +1,10 @@
 #!/bin/bash
+
+# Re-claim memory from an extra rootfs copy if we booted over PXE
+if [[ -d /run/archiso/httpspace ]]; then
+  umount /run/archiso/httpspace
+fi
+
 dhcpcd -w
 
 python3 -u /installer.py


### PR DESCRIPTION
It seems that the image is first copied to /run/archiso/httpspace
followed by a copy to /run/archiso/copytoram. Since copytoram seems to
be not possible to disable, reclaim the httpsace instead.

- [x] Test PXE boot with this change
- [x] Test QEMU boot with this change