### PR TITLE
Implement /v1/machines API on fake-infra

### DIFF
--- a/fake-infra.py
+++ b/fake-infra.py
@@ -34,6 +34,7 @@ class ServiceServer(BaseHTTPRequestHandler):
                 res = {'ssh_pub_key': ssh_pub_key}
                 self.wfile.write(json.dumps(res).encode())
 
+
 class ManagerServer(BaseHTTPRequestHandler):
     def do_POST(self):
         global ssh_pub_key
@@ -52,6 +53,18 @@ class ManagerServer(BaseHTTPRequestHandler):
             self.send_response(404)
             self.end_headers()
             self.wfile.write(b'404 not found')
+
+    def do_GET(self):
+        if self.path.startswith('/v1/machines'):
+            self.send_response(200)
+            self.send_header('Content-type', 'application/json')
+            self.end_headers()
+            res = [{
+                'uuid': '00000000-0000-0000-0000-000000000001',
+                'name': 'qemu',
+            }]
+            self.wfile.write(json.dumps(res).encode())
+
 
 if __name__ == '__main__':
     h = HTTPServer(('127.0.0.1', 7708), ServiceServer)


### PR DESCRIPTION
This makes it possible to use the real Machine Service to interface with
the fake QEMU manager, if one would like to do so.